### PR TITLE
🔨: use mongorestore instead

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,12 @@
- # mongo atlas cluster info
- MONGO_ATLAS_USERNAME=username
- MONGO_ATLAS_PASSWORD=password
- MONGO_ATLAS_CLUSTER=cluster0.example
+# rumour info
+RUMOUR_TOPIC=ottawashooting
+
+# mongodb info
+MONGO_ROOT_USERNAME=root
+MONGO_ROOT_PASSWORD=1234
+MONGO_DATABASE=rumour_tweet
+
+# mongo atlas cluster info
+MONGO_ATLAS_USERNAME=username
+MONGO_ATLAS_PASSWORD=password
+MONGO_ATLAS_CLUSTER=cluster0.example

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,11 @@
+include .env
+
 RESOURCES_PATH := ./resources
 DOCKER_PATH := ${RESOURCES_PATH}/docker
 DOCKER_COMPOSE_FILE := -f ${DOCKER_PATH}/docker-compose.yaml --env-file ./.env
 MONGO_PATH := ${DOCKER_PATH}/mongo
+MONGO_ATLAS_URI := mongodb+srv://${MONGO_ATLAS_USERNAME}:${MONGO_ATLAS_PASSWORD}@${MONGO_ATLAS_CLUSTER}.mongodb.net
+MONGO_DUMP_TEMP := /data/db/dump_tmp
 
 up: down
 	docker-compose ${DOCKER_COMPOSE_FILE} up
@@ -22,3 +26,10 @@ reset: down cleanup/persistence
 	
 cleanup/persistence:
 	sudo rm -rf ${MONGO_PATH}/data/
+
+restore/mongodbatlas:
+	docker exec -it rumour_spreading_mongo bash -c "\
+		mongodump -u ${MONGO_ROOT_USERNAME} -p ${MONGO_ROOT_PASSWORD} -d ${MONGO_DATABASE} --out ${MONGO_DUMP_TEMP} && \
+		mongorestore --drop --uri ${MONGO_ATLAS_URI} ${MONGO_DUMP_TEMP} && \
+		rm -rf ${MONGO_DUMP_TEMP} \
+	"

--- a/resources/docker/docker-compose.yaml
+++ b/resources/docker/docker-compose.yaml
@@ -15,7 +15,7 @@ services:
                 # can choose with this list
                 # charliehebdo, ebola-essien, ferguson, germanwings-crash, ottawashooting, prince-toronto, putinmissing, sydneysiege
                 # if would like to change this value need to run `up --build` once, for re-build docker image
-                RUMOUR_TOPIC: ottawashooting
+                RUMOUR_TOPIC: ${RUMOUR_TOPIC}
         restart: always
         volumes:
             # persistant location
@@ -23,7 +23,6 @@ services:
             # init script
             - ./mongo/init.sh:/docker-entrypoint-initdb.d/init-mongo.sh:ro 
         environment:
-            MONGO_INITDB_ROOT_USERNAME: root
-            MONGO_INITDB_ROOT_PASSWORD: 1234
-            MONGO_INITDB_DATABASE: rumour_tweet
-            MONGO_ATLAS_URI: mongodb+srv://${MONGO_ATLAS_USERNAME}:${MONGO_ATLAS_PASSWORD}@${MONGO_ATLAS_CLUSTER}.mongodb.net
+            MONGO_INITDB_ROOT_USERNAME: ${MONGO_ROOT_USERNAME}
+            MONGO_INITDB_ROOT_PASSWORD: ${MONGO_ROOT_PASSWORD}
+            MONGO_INITDB_DATABASE: ${MONGO_DATABASE}

--- a/resources/docker/mongo/init.sh
+++ b/resources/docker/mongo/init.sh
@@ -5,7 +5,6 @@ echo "************************************************************"
 DATASETDIR="/data/datasets"
 DATASETDB="/data/db"
 DATASETTWEETS="${DATASETDB}/dataset_tweets.json"
-COLLECTIONTWEET="tweets"
 echo "[]" > ${DATASETTWEETS}
 for TWEETDIR in ${DATASETDIR}/*; do
   # source tweet
@@ -23,7 +22,7 @@ mongo ${MONGO_INITDB_DATABASE} \
         --eval "db.createUser({user: '${MONGO_INITDB_ROOT_USERNAME}', pwd: '${MONGO_INITDB_ROOT_PASSWORD}', roles:[{role:'dbOwner', db: '${MONGO_INITDB_DATABASE}'}]});"
         
 # import tweets
-mongoimport -d ${MONGO_INITDB_DATABASE} -c ${COLLECTIONTWEET} --file ${DATASETTWEETS} --jsonArray
+mongoimport -d ${MONGO_INITDB_DATABASE} -c tweets --file ${DATASETTWEETS} --jsonArray
 rm -f ${DATASETTWEETS}
 
 # update annotations
@@ -34,13 +33,6 @@ mongo -u ${MONGO_INITDB_ROOT_USERNAME} -p ${MONGO_INITDB_ROOT_PASSWORD} -- $MONG
     db.tweets.update({ _id: t._id }, { \$set: { "annotations": annoJson }})
   })
 EOF
-
-# import to mogodb atlas
-EXPORTTEMP="${DATASETDB}/export_tmp.json"
-mongoexport -u ${MONGO_INITDB_ROOT_USERNAME} -p ${MONGO_INITDB_ROOT_PASSWORD} -d ${MONGO_INITDB_DATABASE} -c ${COLLECTIONTWEET} --type json --out ${EXPORTTEMP}
-echo ${MONGO_ATLAS_URI}
-mongoimport --uri ${MONGO_ATLAS_URI}/${MONGO_INITDB_DATABASE} --collection ${COLLECTIONTWEET} --file ${EXPORTTEMP}
-rm -f ${EXPORTTEMP}
 echo "************************************************************"
 echo "************************************************************"
 echo "************************************************************"


### PR DESCRIPTION
## Description
Use `mongorestore` as a manual script instead of auto import to "MongoDB Atlas" to preventing import replicated row